### PR TITLE
LTFT initial implementation

### DIFF
--- a/firmware/config/boards/proteus/prepend.txt
+++ b/firmware/config/boards/proteus/prepend.txt
@@ -26,5 +26,5 @@
 
 
 
-#define LUA_SCRIPT_SIZE 12000
+#define LUA_SCRIPT_SIZE 11500
 

--- a/firmware/console/binary/output_channels.txt
+++ b/firmware/console/binary/output_channels.txt
@@ -374,6 +374,7 @@ float mapFast
 	uint16_t autoscale vehicleSpeedKph;@@GAUGE_NAME_VVS@@;"kph",{1/@@PACK_MULT_VSS@@}, 0, 0, 0, 2
 
 	uint16_t autoscale Gego;;"%",0.01,0,50,150,2
+	uint16_t autoscale Ltft;;"%",0.01,0,50,150,2
 
 	uint16_t testBenchIter;;"count",1, 0, 0, 0, 0
 

--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -554,6 +554,7 @@ static void updateFuelCorrections() {
 		engine->outputChannels.fuelPidCorrection[i] = 100.0f * (engine->engineState.stftCorrection[i] - 1.0f);
 	}
 	engine->outputChannels.Gego = 100.0f * engine->engineState.stftCorrection[0];
+	engine->outputChannels.Ltft = 100.0f * engine->engineState.ltftCorrection;
 }
 
 static void updateFuelResults() {

--- a/firmware/controllers/algo/accel_enrichment.cpp
+++ b/firmware/controllers/algo/accel_enrichment.cpp
@@ -42,8 +42,10 @@ float TpsAccelEnrichment::getTpsEnrichment() {
 	if (isAboveAccelThreshold) {
 		valueFromTable = tpsTpsMap.getValue(tpsFrom, tpsTo);
 		extraFuel = valueFromTable;
+		m_timeSinceAccel.reset();
 	} else if (isBelowDecelThreshold) {
 		extraFuel = deltaTps * engineConfiguration->tpsDecelEnleanmentMultiplier;
+		m_timeSinceAccel.reset();
 	} else {
 		extraFuel = 0;
 	}
@@ -193,9 +195,14 @@ void TpsAccelEnrichment::onConfigurationChange(engine_configuration_s const* /*p
 	setLength(length);
 }
 
+float TpsAccelEnrichment::getTimeSinceAcell() const {
+	return m_timeSinceAccel.getElapsedSeconds();
+}
+
 void initAccelEnrichment() {
 	tpsTpsMap.initTable(config->tpsTpsAccelTable, config->tpsTpsAccelToRpmBins, config->tpsTpsAccelFromRpmBins);
 
 	engine->module<TpsAccelEnrichment>()->onConfigurationChange(nullptr);
 }
+
 

--- a/firmware/controllers/algo/accel_enrichment.h
+++ b/firmware/controllers/algo/accel_enrichment.h
@@ -11,12 +11,14 @@
 
 #include "cyclic_buffer.h"
 #include "table_helper.h"
+#include <rusefi/timer.h>
 #include "wall_fuel_state_generated.h"
 #include "tps_accel_state_generated.h"
 
 typedef Map3D<TPS_TPS_ACCEL_TABLE, TPS_TPS_ACCEL_TABLE, float, float, float> tps_tps_Map3D_t;
 
 class TpsAccelEnrichment : public tps_accel_state_s, public EngineModule {
+	Timer m_timeSinceAccel;
 public:
 	TpsAccelEnrichment();
 
@@ -37,6 +39,8 @@ public:
 	void onEngineCycleTps();
 	void resetFractionValues();
 	void resetAE();
+	float getTimeSinceAcell() const;
+
 };
 
 void initAccelEnrichment();

--- a/firmware/controllers/algo/engine.h
+++ b/firmware/controllers/algo/engine.h
@@ -56,6 +56,7 @@
 #include "efi_output.h"
 #include "vvt.h"
 #include "trip_odometer.h"
+#include "closed_loop_fuel.h"
 
 #include <functional>
 
@@ -171,6 +172,7 @@ public:
 		BoostController,
 #endif // EFI_BOOST_CONTROL
 		TpsAccelEnrichment,
+		LongTermFuelTrim,
 		EngineModule // dummy placeholder so the previous entries can all have commas
 		> engineModules;
 

--- a/firmware/controllers/algo/engine_state.h
+++ b/firmware/controllers/algo/engine_state.h
@@ -37,6 +37,7 @@ public:
 	float injectionMass[MAX_CYLINDER_COUNT] = {0};
   // todo: move to .txt or even better extract injection.txt?
 	float stftCorrection[STFT_BANK_COUNT] = {0};
+	float ltftCorrection = {0};
 
 	float injectionStage2Fraction = 0;
 

--- a/firmware/controllers/math/closed_loop_fuel.h
+++ b/firmware/controllers/math/closed_loop_fuel.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "table_helper.h"
+
 struct stft_s;
 
 struct ClosedLoopFuelResult {
@@ -13,6 +15,19 @@ struct ClosedLoopFuelResult {
 	float banks[STFT_BANK_COUNT];
 };
 
-ClosedLoopFuelResult fuelClosedLoopCorrection();
+ClosedLoopFuelResult fuelStftClosedLoopCorrection();
 size_t computeStftBin(float rpm, float load, stft_s& cfg);
 bool shouldUpdateCorrection(SensorType sensor);
+
+class LongTermFuelTrim : public EngineModule{
+		float ltftTableHelper[16][16];
+		bool ltftTableHelperInit = 0;
+		uint32_t lastLtftUpdateTime = 0;
+		float ltftResult = 1;
+		bool updatedLtft = 0;
+	public:
+		void onIgnitionStateChanged(bool ignitionOn);
+		float getLtft(float load, float rpm);
+		void resetLtftTimer();
+		void updateLtft(float load, float rpm);
+};

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1022,6 +1022,7 @@ bit verboseCan2,"Print all","Do not print";Print incoming and outgoing second bu
 
 	uint8_t autoscale tpsAccelLookback;How long to look back for TPS-based acceleration enrichment. Increasing this time will trigger enrichment for longer when a throttle position change occurs.;"sec", 0.05, 0, 0, 5, 2
 	uint8_t autoscale noFuelTrimAfterDfcoTime;Pause closed loop fueling after deceleration fuel cut occurs. Set this to a little longer than however long is required for normal fueling behavior to resume after fuel cut.;"sec", 0.1, 0, 0, 10, 1
+	uint8_t autoscale noFuelTrimAfterAccelTime;Pause closed loop fueling after acceleration fuel occurs. Set this to a little longer than however long is required for normal fueling behavior to resume after fuel accel.;"sec", 0.1, 0, 0, 10, 1
 
     int launchSpeedThreshold;Launch disabled above this speed if setting is above zero;"Kph", 1, 0, 0, 300, 0
     int launchRpmWindow;Starting Launch RPM window to activate (subtracts from Launch RPM);"RPM", 1, 0, 0, 8000, 0
@@ -1880,6 +1881,16 @@ uint16_t[IGN_RPM_COUNT] ignitionRpmBins;;"RPM",	   1, 0, 0, 18000, 0
 uint16_t[FUEL_LOAD_COUNT x FUEL_RPM_COUNT] autoscale veTable;;"%", 0.1, 0, 0, 999, 1
 uint16_t[FUEL_LOAD_COUNT] veLoadBins;;{bitStringValue(fuelUnits, fuelAlgorithm) },	1, 0, 0, 1000, 0
 uint16_t[FUEL_RPM_COUNT] veRpmBins;;"RPM",	   1, 0, 0, 18000, 0
+
+uint16_t[FUEL_LOAD_COUNT x FUEL_RPM_COUNT] autoscale ltftTable;;"%", 0.1, 0, 0, 999, 1
+uint16_t[FUEL_LOAD_COUNT x FUEL_RPM_COUNT] autoscale ltftCorrectionRate;;"10x%/s", 0.1, 0, 0, 99, 1
+bit ltftEnabled
+uint8_t ltftCRC;;"value", 1, 0, 0, 255, 0
+uint8_t ltftMinModTemp;Minimum temperature to start correcting ltft tables;"deg C", 1, 0, 0, 150, 0
+uint8_t ltftMinTemp;Minimum temperature to start using ltft tables;"deg C", 1, 0, 0, 150, 0
+uint8_t ltftPermissivity;How much long term fuel trim should act to reduce short term fuel trim, 100 should keep stft in about 3%, 255 in 8% and 33 in 1%, and ;"%", 1, 0, 0, 255, 0
+uint8_t ltftMaxCorrection;;"%", 1, 0, 0, 50, 0
+uint8_t ltftMinCorrection;;"%", 1, 0, 0, 50, 0
 
 #if LAMBDA
 uint8_t[FUEL_LOAD_COUNT x FUEL_RPM_COUNT] autoscale lambdaTable;;"lambda", {1/@@PACK_MULT_LAMBDA_CFG@@}, 0, 0.6, 1.5, 2

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -1179,6 +1179,22 @@ curve = rangeMatrix, "Range Switch Input Matrix"
 		gridOrient  = 250,	0, 340 ; Space 123 rotation of grid in degrees.
 		upDownLabel = "(RICHER)", "(LEANER)"
 
+	table = ltftTableTbl,  ltftTableMap,  "Long Term Fuel Trim Table", 1
+		xyLabels = "RPM", "load"
+		xBins		= veRpmBins,  RPMValue
+		yBins		= veLoadBins, veTableYAxis
+		zBins		= ltftTable
+;		gridHeight  = 2.0
+		gridOrient  = 250,	0, 340 ; Space 123 rotation of grid in degrees.
+
+	table = ltftCorrectionRateTbl,  ltftCorrectionRateMap,  "Long Term Fuel Trim Correction Rate Table", 1
+		xyLabels = "RPM", "load"
+		xBins		= veRpmBins,  RPMValue
+		yBins		= veLoadBins, veTableYAxis
+		zBins		= ltftCorrectionRate
+;		gridHeight  = 2.0
+		gridOrient  = 250,	0, 340 ; Space 123 rotation of grid in degrees.
+
 	table = idleVeTableTbl, idleVeTable, "Idle VE"
 		xyLabels = "RPM", "load"
 		xBins		= idleVeRpmBins,  RPMValue
@@ -1657,7 +1673,7 @@ gaugeCategory = Fueling
 	actualLastInjectionStg2Gauge	= actualLastInjectionStage2,	@@GAUGE_NAME_FUEL_LAST_INJECTION_STAGE_2@@, "mSec",		0,	25.5,	1.0,	1.2,		20,	25,	3, 1
 	veValueGauge		= veValue,					"fuel: VE",				"",		0,	120,		10,	10,	100,	100,	1,	1
   gegoGauge            = Gego,                                      "EGO",                             "",             50,      160,            10,     10,     100,    100,    1,      1
-
+ ltftGauge            = Ltft,                                      "LTFT",                             "",             50,      160,            10,     10,     100,    100,    1,      1
 	injectorLagMsGauge = m_deadtime,		@@GAUGE_NAME_INJECTOR_LAG@@,		"mSec",		0,	10,	0,	0,		10,	10,	3, 1
 	fuelRunningGauge	= running_fuel,		@@GAUGE_NAME_FUEL_RUNNING@@,		"mg",		0,	100,	0,	0,		100,	100,	3, 1
 	baseFuelGauge	= running_baseFuel,		@@GAUGE_NAME_FUEL_BASE@@,		"mg",		0,	100, 0, 0, 100, 100,	2, 0
@@ -1990,7 +2006,12 @@ menuDialog = main
 
 		subMenu = cltFuelCorrCurve,			"CLT multiplier", 0, {isInjectionEnabled == 1}
 		subMenu = iatFuelCorrCurve,			"IAT multiplier", 0, {isInjectionEnabled == 1}
-		subMenu = fuelClosedLoopDialog,	"Closed loop fuel correction", 0, {isInjectionEnabled == 1}
+		subMenu = fuelClosedLoopDialog,		"Closed loop fuel correction", 0, {isInjectionEnabled == 1}
+		subMenu = ltftConfiguration,		"Long term fuel trim correction", 0, {fuelClosedLoopCorrectionEnabled == 1}
+		groupMenu = "Long term fuel trim tables"
+		groupChildMenu = ltftTableTbl,    	"LTFT map", 0, {ltftEnabled == 1}
+		groupChildMenu = ltftCorrectionRateTbl,    "LTFT corrrection rate", 0, {ltftEnabled == 1}
+		
 		subMenu = coastingFuelCutControl,	"Deceleration fuel cutoff (DFCO)", 0, {isInjectionEnabled == 1}
 		subMenu = std_separator
 
@@ -4125,6 +4146,14 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		panel = stftPartitionSettingsPower, {fuelClosedLoopCorrectionEnabled == 1}
 		panel = stftPartitionSettingsOverrun, {fuelClosedLoopCorrectionEnabled == 1}
 
+	dialog = ltftConfiguration, "Long term fuel trim configuration"
+		field = "Enabled",								ltftEnabled
+		field = "Correction upper limit",				ltftMaxCorrection, {ltftEnabled == 1}
+		field = "Correction lower limit",				ltftMinCorrection, {ltftEnabled == 1}
+		field = "Minimum temperature to actuate",	    ltftMinTemp, {ltftEnabled == 1}
+		field = "Minimum temperature to modify tables", ltftMinModTemp, {ltftEnabled == 1}
+		field = "Long term fuel trim permissivity",		ltftPermissivity, {ltftEnabled == 1}
+
 	dialog = lambdaProtectionLeft, ""
 		field = "Enable lambda protection", lambdaProtectionEnable
 		field = "Check above load", lambdaProtectionMinLoad, { lambdaProtectionEnable }
@@ -4432,7 +4461,8 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 
 	dialog = TpsAccelPanel, "TPS"
 		field = "Set 'Debug Mode' to see detailed 'TPS acceleration enrichment' diagnostics"
-			field = "Length",						tpsAccelLookback
+		field = "Inhibit closed loop fuel after accel", noFuelTrimAfterAccelTime
+		field = "Length",						tpsAccelLookback
 		field = "Accel Threshold",				tpsAccelEnrichmentThreshold
 		field = "Decel Threshold",				tpsDecelEnleanmentThreshold
 ;		field = "Decel Multiplier",				tpsDecelEnleanmentMultiplier


### PR DESCRIPTION
For this the ECU must be always on 5V

It's based on STFT and an bias curve. The correction is linear if STFT greater than as threshold defined by: (1-10^ (-20*abs(1-STFT))), so, the correction must be stable;

We have some limits on the correction, using CLT sensor, of using the LTFT table and modifying it.

Was implemented a delay on  the correction after fast acceleration by TPS, as it could be an problem to the correction.

Some minor details...